### PR TITLE
Normalize numerical location by adding leading zeroes to northing and…

### DIFF
--- a/mgrs.js
+++ b/mgrs.js
@@ -359,8 +359,10 @@ function getLetterDesignator(lat) {
  * @return {string} MGRS string for the given UTM location.
  */
 function encode(utm, accuracy) {
-  var seasting = "" + utm.easting,
-    snorthing = "" + utm.northing;
+  // add 100,000 to numerical locations to create leading zeroes in string
+  // the additional leading 1 will be truncated in the subsequent 'substr' commands
+  var seasting = "" + (utm.easting + 100000),
+    snorthing = "" + (utm.northing + 100000);
 
   return utm.zoneNumber + utm.zoneLetter + get100kID(utm.easting, utm.northing, utm.zoneNumber) + seasting.substr(seasting.length - 5, accuracy) + snorthing.substr(snorthing.length - 5, accuracy);
 }

--- a/mgrs.js
+++ b/mgrs.js
@@ -37,7 +37,7 @@ var Z = 90; // Z
  * @param {object} ll Object literal with lat and lon properties on a
  *     WGS84 ellipsoid.
  * @param {int} accuracy Accuracy in digits (5 for 1 m, 4 for 10 m, 3 for
- *      100 m, 4 for 1000 m or 5 for 10000 m). Optional, default is 5.
+ *      100 m, 2 for 1000 m or 1 for 10000 m). Optional, default is 5.
  * @return {string} the MGRS string for the given location and accuracy.
  */
 exports.forward = function(ll, accuracy) {
@@ -359,10 +359,9 @@ function getLetterDesignator(lat) {
  * @return {string} MGRS string for the given UTM location.
  */
 function encode(utm, accuracy) {
-  // add 100,000 to numerical locations to create leading zeroes in string
-  // the additional leading 1 will be truncated in the subsequent 'substr' commands
-  var seasting = "" + (utm.easting + 100000),
-    snorthing = "" + (utm.northing + 100000);
+  // prepend with leading zeroes
+  var seasting = "00000" + utm.easting,
+    snorthing = "00000" + utm.northing;
 
   return utm.zoneNumber + utm.zoneLetter + get100kID(utm.easting, utm.northing, utm.zoneNumber) + seasting.substr(seasting.length - 5, accuracy) + snorthing.substr(snorthing.length - 5, accuracy);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -28,4 +28,10 @@ describe('Second MGRS set', function() {
   it('MGRS reference with 1-digit accuracy correct.', function() {
     mgrs.forward(point,3).should.equal('25XEN041865');
   });
+  it('MGRS reference with 5-digit accuracy, northing all zeros', function(){
+    mgrs.forward([0,0],5).should.equal('31NAA6602100000');
+  });
+  it('MGRS reference with 5-digit accuracy, northing one digit', function(){
+    mgrs.forward([0,0.00001],5).should.equal('31NAA6602100001');
+  });
 })


### PR DESCRIPTION
… easting components of mgrs coordinte and add two tests to verify.
Without the leading zeroes added to the northing component, invalid or inaccurate mgrs coordinates can be created by the 'forward' method. 
As an example, forward([0,0]) yielded: '31NAA660210', instead of '31NAA6602100000'. The northing component was 0 numerically and then converted to a string '0'. 
The fix I propose is to add 100,000 to the numerical version that will then create the string: '100000'. The subsequent 'substr' command takes the will extract the right number of zeroes based on the accuracy. 
I only saw the problem with the northing piece, but I applied the same fix to the easting as well.  