### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "mgrs",
+  "description": "Utility for converting between WGS84 lat/lng and MGRS coordinates",
+  "main": "mgrs.js",
+  "authors": [
+    "Proj4 Team",
+    "OpenMap",
+    "Mike Adair",
+    "Richard Greenwood",
+    "Didier Richard",
+    "Stephen Irons",
+    "Olivier Terral",
+    "Calvin Metcalf"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "mgrs",
+    "proj4",
+    "gis"
+  ],
+  "homepage": "",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I am interested in adding this project to Bower. I can register it once the `bower.json` file is in place.

I know there hasn't been much activity, but this library is quite useful for many projects.
- I pointed the main location in the bower file to `mgrs.js` in the root, not the `dist` folder. Partly because the `dist` file doesn't provide any additional build work. The main reason I did this is it looks like `dist/mgrs.js` was not updated at the time of the latest tag `@0.0.4`
