### PR TITLE
toPoint throws an error if a blank string is passed in

### DIFF
--- a/mgrs.js
+++ b/mgrs.js
@@ -86,6 +86,9 @@ export function inverse(mgrs) {
 }
 
 export function toPoint(mgrs) {
+  if (mgrs === '') {
+    throw (`toPoint received a blank string`);
+  }
   const bbox = UTMtoLL(decode(mgrs.toUpperCase()));
   if (bbox.lat && bbox.lon) {
     return [bbox.lon, bbox.lat];

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,13 @@ describe ('third mgrs set', () => {
 
 describe ('data validation', () => {
   describe('forward function', () => {
+    it('toPoint throws an error when a blank string is passed in', () => {
+      try {
+        mgrs.toPoint('');
+      } catch (error) {
+        error.should.equal('toPoint received a blank string');
+      }
+    });
     it('forward throws an error when array of strings passed in', () => {
       try {
         mgrs.forward(['40', '40']);


### PR DESCRIPTION
Added simple validation to the toPoint function, so that it throws a more descriptive error if a user passes in a blank string.