### PR TITLE
use object literal property value shorthand and object destructuring

### DIFF
--- a/mgrs.js
+++ b/mgrs.js
@@ -28,9 +28,9 @@ const O = 79; // O
 const V = 86; // V
 const Z = 90; // Z
 export default {
-  forward: forward,
-  inverse: inverse,
-  toPoint: toPoint
+  forward,
+  inverse,
+  toPoint
 };
 
 
@@ -216,8 +216,7 @@ function UTMtoLL(utm) {
 
   const UTMNorthing = utm.northing;
   const UTMEasting = utm.easting;
-  const zoneLetter = utm.zoneLetter;
-  const zoneNumber = utm.zoneNumber;
+  const { zoneLetter, zoneNumber } = utm;
   // check the ZoneNummber is valid
   if (zoneNumber < 0 || zoneNumber > 60) {
     return null;
@@ -283,8 +282,8 @@ function UTMtoLL(utm) {
   }
   else {
     result = {
-      lat: lat,
-      lon: lon
+      lat,
+      lon
     };
   }
   return result;
@@ -506,7 +505,7 @@ function decode(mgrsString) {
     throw new TypeError('MGRSPoint coverting from nothing');
   }
 
-  const length = mgrsString.length;
+  const { length } = mgrsString;
 
   let hunK = null;
   let sb = '';
@@ -579,10 +578,10 @@ northing meters ${mgrsString}`);
   const northing = sepNorthing + north100k;
 
   return {
-    easting: easting,
-    northing: northing,
-    zoneLetter: zoneLetter,
-    zoneNumber: zoneNumber,
+    easting,
+    northing,
+    zoneLetter,
+    zoneNumber,
     accuracy: accuracyBonus
   };
 }


### PR DESCRIPTION
Minor Changes to Simplify Code
- Use object destructuring when the new variable has the same name as the key from the object being pulled
- Use object literal variable shorthand when creating objects

Tests pass:
![image](https://user-images.githubusercontent.com/4313463/56673233-e4fd4d80-6685-11e9-9d62-0132934c0335.png)

