### PR TITLE
GEOTRANS check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .DS_STORE
 coverage
 .nyc_output
+*.csv
+*.tgz
+geotrans3.7/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,6 +1131,12 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "mgrs.js",
   "scripts": {
     "lint": "eslint mgrs.js && eslint test",
-    "test": "npm run build && nyc mocha",
+    "test": "npm run build && nyc mocha test/test.js",
     "build": "mkdir -p dist && rollup -c"
   },
   "repository": {
@@ -27,6 +27,7 @@
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "mocha": "^6.1.1",
+    "node-fetch": "^2.5.0",
     "nyc": "^13.3.0",
     "rollup": "^1.9.0"
   }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,36 @@
+const { writeFileSync } = require('fs');
+const fetch = require('node-fetch');
+
+async function process() {
+  // originally downloaded from
+  // http://earth-info.nga.mil/GandG/update/index.php?action=home
+  // and found in the unpacked downloaded GEOTRANS folder at
+  // geotrans3.7/SpreadsheetTester/TestFiles/outputs/output/mgrsToGeo_WE.txt
+  const url = 'https://s3.amazonaws.com/mgrs.io/mgrsToGeo_WE.txt';
+
+  let text = await fetch(url).then(response => response.text());
+
+  const [header, description, blank, ...rows] = text.split('\r\n');
+
+  let testCases = rows
+  .filter(testCase => {
+    return testCase.includes('Successful-Equivalent');
+  })
+  .map(row => {
+    const cells = row.replace(/\t+/g, '\t').split('\t');
+    return {
+      latitude: cells[6].trim(),
+      longitude: cells[7].trim(),
+      mgrs: cells[5].trim()
+    };
+  })
+
+
+  console.log("testCases", testCases);
+  const csv = testCases.map(({mgrs, latitude, longitude}) => `${mgrs}\t${latitude}\t${longitude}`).join('\n');
+  writeFileSync('testing-data.csv', csv, 'utf8');
+
+  console.log("wrote testing-data.csv");
+}
+
+process();

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 const should = require('chai').should(); // eslint-disable-line no-unused-vars
 const mgrs = require('../dist/mgrs');
+const { readFileSync } = require('fs');
 
 describe('First MGRS set', () => {
   const mgrsStr = '33UXP04';
@@ -111,3 +112,23 @@ describe ('data validation', () => {
     });
   });
 });
+
+if (process.env.CHECK_GEOTRANS) {
+  describe('Consistency with GEOTRANS', () => {
+    it('Should be consistent with GEOTRANS', () => {
+      const fileText = readFileSync('./test/testing-data.csv', 'utf8');
+      const lines = fileText.split('\n').filter(Boolean);
+      lines.forEach(line => {
+        const [ mgrsString, expectedLatitude, expectedLongitude ] = line.split('\t');
+        const [ actualLongitude, actualLatitude ] = mgrs.toPoint(mgrsString);
+        try {
+          actualLatitude.should.equal(expectedLatitude);
+          actualLongitude.should.equal(expectedLongitude);
+        } catch (error) {
+          console.error('mgrsString:', mgrsString);
+          throw error;
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
I add some code to check the consistency of mgrs results with GEOTRANS.  This test is not enabled by default and can be activated with an environmental variable.  To have it include in the test-run, run
```bash
CHECK_GEOTRANS=true npm test
```

This additional test helped me identify this bug: https://github.com/proj4js/mgrs/issues/41