### PR TITLE
updated tests to work with new version of GEOTRANS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,26 +936,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -996,6 +976,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "iconv-lite": {
@@ -1270,12 +1256,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest-worker": {
@@ -1494,12 +1480,20 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -1531,6 +1525,27 @@
         "yargs": "13.2.2",
         "yargs-parser": "13.0.0",
         "yargs-unparser": "1.5.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "ms": {
@@ -1549,12 +1564,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -1716,24 +1725,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        }
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
@@ -2164,9 +2155,9 @@
       }
     },
     "spawn-wrap": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
       "dev": true,
       "requires": {
         "foreground-child": "^1.5.6",
@@ -2397,33 +2388,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2618,9 +2582,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "pretest": "npm run clean && npm run build",
     "test": "nyc mocha test/test.js",
     "clean": "rimraf dist",
-    "build": "mkdir dist && rollup -c"
+    "build": "mkdir dist && rollup -c",
+    "setup": "cd test && node setup.js"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/proj4js/mgrs.git"
   },
   "keywords": [
+    "geodesy",
     "mgrs",
     "proj4",
     "gis"

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,16 +2,16 @@ const { writeFileSync } = require('fs');
 const fetch = require('node-fetch');
 
 async function process() {
-  // originally downloaded from
-  // http://earth-info.nga.mil/GandG/update/index.php?action=home
-  // and found in the unpacked downloaded GEOTRANS folder at
-  // geotrans3.7/SpreadsheetTester/TestFiles/outputs/output/mgrsToGeo_WE.txt
+  // mgrsToGeo_WE.txt was originally created by running the tests
+  // for GEOTRANS version 3.8 in the geodesy/geotrans docker image
+  // and found at the following path
+  // geotrans3.8/SpreadsheetTester/TestFiles/outputs/output/mgrsToGeo_WE.txt
   const url = 'https://s3.amazonaws.com/mgrs.io/mgrsToGeo_WE.txt';
 
   const text = await fetch(url).then(response => response.text());
 
   // eslint-disable-next-line no-unused-vars
-  const [header, description, blank, ...rows] = text.split('\r\n');
+  const [header, description, blank, ...rows] = text.split(/\r?\n/);
 
   const testCases = rows
     .filter(testCase => {
@@ -20,15 +20,15 @@ async function process() {
     .map(row => {
       const cells = row.replace(/\t+/g, '\t').split('\t');
       return {
-        latitude: cells[6].trim(),
-        longitude: cells[7].trim(),
+        latitude: cells[9].trim(),
+        longitude: cells[10].trim(),
         mgrs: cells[5].trim()
       };
     });
 
 
   console.log('testCases', testCases);
-  const csv = testCases.map(({ mgrs, latitude, longitude }) => `${mgrs}\t${latitude}\t${longitude}`).join('\n');
+  const csv = 'mgrs,longitude,latitude\n' + testCases.map(({ mgrs, latitude, longitude }) => `${mgrs}\t${longitude}\t${latitude}`).join('\n');
   writeFileSync('testing-data.csv', csv, 'utf8');
 
   console.log('wrote testing-data.csv');

--- a/test/test.js
+++ b/test/test.js
@@ -133,13 +133,19 @@ if (process.env.CHECK_GEOTRANS) {
   describe('Consistency with GEOTRANS', () => {
     it('Should be consistent with GEOTRANS', () => {
       const fileText = readFileSync('./test/testing-data.csv', 'utf8');
-      const lines = fileText.split('\n').filter(Boolean);
+      const lines = fileText.split('\n')
+        .filter(Boolean) // remove blank lines if any
+        .slice(1); // remove header
       lines.forEach(line => {
-        const [ mgrsString, expectedLatitude, expectedLongitude ] = line.split('\t');
+        const [ mgrsString, expectedLongitude, expectedLatitude ] = line.split('\t');
+
+        // mgrs library doesn't support polar regions
+        if (['A','B','Y','Z'].includes(mgrsString[0])) return;
+
         const [ actualLongitude, actualLatitude ] = mgrs.toPoint(mgrsString);
         try {
-          actualLatitude.should.equal(expectedLatitude);
-          actualLongitude.should.equal(expectedLongitude);
+          actualLatitude.should.be.closeTo(Number.parseFloat(expectedLatitude), 0.0000015);
+          actualLongitude.should.be.closeTo(Number.parseFloat(expectedLongitude), 0.0000015);
         } catch (error) {
           console.error('mgrsString:', mgrsString);
           throw error;


### PR DESCRIPTION
NGA recently released a new version of GEOTRANS, version 3.8, which included a change to the MGRS calculation.  The new formula now uses the center of the box (which is what this library uses).  This Pull Request mostly updates the test files taken from GEOTRANS.  Here's a screenshot from the relevant section on https://earth-info.nga.mil/GandG/update/index.php?action=home:
<img width="935" alt="Screen Shot 2020-08-07 at 10 29 29 PM" src="https://user-images.githubusercontent.com/4313463/89701536-776a4480-d8fd-11ea-99aa-203bf67ab260.png">

I also updated the GEOTRANS consistency test, to check if the results from this library are within `0.0000015` degrees of the results given by GEOTRANS.

I also added 'geodesy' as a keyword in the package.json.

I'll leave this open here until 8/14 and will merge shortly thereafter barring any comments to the contrary.

I also updated the package-lock.json after running `npm audit --fix`.

Thank you and let me know if that are any questions.