### PR TITLE
WIP: added code so decode always returns accuracyBonus even if 100k

### DIFF
--- a/mgrs.js
+++ b/mgrs.js
@@ -547,12 +547,11 @@ northing meters ${mgrsString}`);
 
   let sepEasting = 0;
   let sepNorthing = 0;
-  let accuracyBonus, sepEastingString, sepNorthingString;
+  const accuracyBonus = 100000 / Math.pow(10, sep);
   if (sep > 0) {
-    accuracyBonus = 100000 / Math.pow(10, sep);
-    sepEastingString = mgrsString.substring(i, i + sep);
+    const sepEastingString = mgrsString.substring(i, i + sep);
     sepEasting = parseFloat(sepEastingString) * accuracyBonus;
-    sepNorthingString = mgrsString.substring(i + sep);
+    const sepNorthingString = mgrsString.substring(i + sep);
     sepNorthing = parseFloat(sepNorthingString) * accuracyBonus;
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -140,6 +140,12 @@ describe ('data validation', () => {
       center[1].should.be.closeTo((bbox[1] + bbox[3]) / 2, 1e-9);
       mgrs.forward(center, 0).should.equal('33UXP');
     });
+    it('toPoint returns the center of the square and round-trips (2)', () => {
+      const center = mgrs.toPoint('34PBQ');
+      center[0].should.be.closeTo(18.729117730990232, 1e-9);
+      center[1].should.be.closeTo(8.587478059960034, 1e-9);
+      mgrs.forward(center, 0).should.equal('34PBQ');
+    })
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,20 @@ describe ('data validation', () => {
       letter.should.equal('Z');
     });
   });
+  describe('0-digit accuracy (100 km square)', () => {
+    it('inverse returns the full square, not a zero-size box', () => {
+      const bbox = mgrs.inverse('33UXP');
+      (bbox[2] - bbox[0]).should.be.greaterThan(0.5);
+      (bbox[3] - bbox[1]).should.be.greaterThan(0.5);
+    });
+    it('toPoint returns the centre of the square and round-trips', () => {
+      const bbox = mgrs.inverse('33UXP');
+      const center = mgrs.toPoint('33UXP');
+      center[0].should.be.closeTo((bbox[0] + bbox[2]) / 2, 1e-9);
+      center[1].should.be.closeTo((bbox[1] + bbox[3]) / 2, 1e-9);
+      mgrs.forward(center, 0).should.equal('33UXP');
+    });
+  });
 });
 
 if (process.env.CHECK_GEOTRANS) {


### PR DESCRIPTION
This should fix #29 .

I haven't tested toPoint on 100k MGRS strings, but my quick read through the code makes me thin this might change the result of toPoint for a 100k from the bottom left to the centroid.  The centroid is now correct, but I want to make sure this change in functionality and results has a test case for it before requesting a new version is published.

If you want to use this functionality now, you can copy the mgrs.js file in the root directory.  (I haven't run build, so dist/mgrs.js is the old version that is on NPM)